### PR TITLE
Move to subdomains

### DIFF
--- a/.artifacts.yml
+++ b/.artifacts.yml
@@ -1,0 +1,3 @@
+version: v1
+defaults:
+  - publisher

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
   <meta charset=utf-8 />
   <title>Malaria Mapping</title>
+  <link rel="canonical" href="https://labs.mapbox.com/malaria-mapping/" >
   <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.36.0/mapbox-gl.js'></script>
   <script src='https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js'></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1756 @@
+{
+  "name": "@mapbox/malaria-mapping",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@mapbox/geojson-area": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+      "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
+      "requires": {
+        "wgs84": "0.0.0"
+      }
+    },
+    "@turf/along": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-4.7.3.tgz",
+      "integrity": "sha1-pJgfJUzH8Ko3E77i51X+81BrhRg=",
+      "requires": {
+        "@turf/bearing": "^4.7.3",
+        "@turf/destination": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/area": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-4.7.3.tgz",
+      "integrity": "sha1-XMRbWlJOmOHBcecZBwnGacppkwU=",
+      "requires": {
+        "@mapbox/geojson-area": "^0.2.2",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/bbox": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-4.7.3.tgz",
+      "integrity": "sha1-461PEKfptBtSKIDTMIMZgZkFkGc=",
+      "requires": {
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/bbox-clip": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-4.7.3.tgz",
+      "integrity": "sha1-umicgKTMOLLsU51t6agxCH9FDAk=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "lineclip": "^1.1.5"
+      }
+    },
+    "@turf/bbox-polygon": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-4.7.3.tgz",
+      "integrity": "sha1-NYiQ/R8abK2anLUHmeNzJfuIAXo=",
+      "requires": {
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/bearing": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-4.7.3.tgz",
+      "integrity": "sha1-79GopcjKDNvsvMAhcsQe0hbf+Pk=",
+      "requires": {
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/bezier": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/bezier/-/bezier-4.7.3.tgz",
+      "integrity": "sha1-NL3Y6W8icmqtHzVoMXOILPYWvkg=",
+      "requires": {
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/boolean-clockwise": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-4.7.3.tgz",
+      "integrity": "sha1-BieRaxxD4G4A7SyBF7IM+m+/cBQ=",
+      "requires": {
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/boolean-contains": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-4.7.3.tgz",
+      "integrity": "sha1-HWQFdZDXV1FvUpfKfZDBjL2GTJg=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/boolean-point-on-line": "^4.7.3",
+        "@turf/inside": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/boolean-crosses": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-4.7.3.tgz",
+      "integrity": "sha1-N4Yt2druGH4m+tf/Q/tkqjj7sIA=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/inside": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/line-intersect": "^4.7.3",
+        "@turf/polygon-to-linestring": "^4.7.3"
+      }
+    },
+    "@turf/boolean-disjoint": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-4.7.3.tgz",
+      "integrity": "sha1-V6KCTeiq575532OBKF0hM3tR3CE=",
+      "requires": {
+        "@turf/inside": "^4.7.3",
+        "@turf/line-intersect": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/polygon-to-linestring": "^4.7.3"
+      }
+    },
+    "@turf/boolean-equal": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-4.7.3.tgz",
+      "integrity": "sha1-yqkV3rU7/d0/ErBmXsWv2eC9ydY=",
+      "requires": {
+        "@turf/clean-coords": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-overlap": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-4.7.3.tgz",
+      "integrity": "sha1-j4pRaNN6zlFYz/b0sMI03TdsG0g=",
+      "requires": {
+        "@turf/invariant": "^4.7.3",
+        "@turf/line-intersect": "^4.7.3",
+        "@turf/line-overlap": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-point-on-line": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-4.7.3.tgz",
+      "integrity": "sha1-aO6XtwvGJV9nzR5RpFZYQRvLl5k=",
+      "requires": {
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/boolean-within": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-4.7.3.tgz",
+      "integrity": "sha1-J6V5SbOytFKNbQRX8D7dMwTgXKw=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/boolean-point-on-line": "^4.7.3",
+        "@turf/inside": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/buffer": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-4.7.4.tgz",
+      "integrity": "sha1-6vB0cFGowyQtsng9mDJCGsLuP7s=",
+      "requires": {
+        "@turf/bbox": "^4.7.1",
+        "@turf/center": "4.7.1",
+        "@turf/helpers": "4.7.1",
+        "@turf/meta": "4.7.1",
+        "@turf/projection": "^4.7.1",
+        "d3-geo": "^1.6.3",
+        "jsts": "1.3.0"
+      },
+      "dependencies": {
+        "@turf/center": {
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/@turf/center/-/center-4.7.1.tgz",
+          "integrity": "sha1-XGbFYUTwfDXiYpLKYbQQWxtTqNI=",
+          "requires": {
+            "@turf/bbox": "4.7.1",
+            "@turf/helpers": "4.7.1"
+          },
+          "dependencies": {
+            "@turf/bbox": {
+              "version": "4.7.1",
+              "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-4.7.1.tgz",
+              "integrity": "sha1-wvBewr7BC5o7TgRUAKr6s1svTP8=",
+              "requires": {
+                "@turf/meta": "4.7.1"
+              }
+            }
+          }
+        },
+        "@turf/helpers": {
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-4.7.1.tgz",
+          "integrity": "sha1-Es7L/iKxY4YzhTfa4+Pag94vP6w="
+        },
+        "@turf/meta": {
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-4.7.1.tgz",
+          "integrity": "sha1-U6VSga4IpfovQU2bpQqVHTjoarU="
+        }
+      }
+    },
+    "@turf/center": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-4.7.3.tgz",
+      "integrity": "sha1-dE5cZSp7G70OHuPwXjDd5D4qNaQ=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/center-of-mass": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-4.7.3.tgz",
+      "integrity": "sha1-Z6ZlxwTjNLz/jiiXdV+8K7MnvJs=",
+      "requires": {
+        "@turf/centroid": "^4.7.3",
+        "@turf/convex": "^4.7.3",
+        "@turf/explode": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/centroid": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-4.7.3.tgz",
+      "integrity": "sha1-IFp2dXGbDI4XW7dWXF1v4mfYgXU=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/circle": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-4.7.3.tgz",
+      "integrity": "sha1-6PmW/4ewyo4+a3S2D2q12vkIZxM=",
+      "requires": {
+        "@turf/destination": "^4.7.3",
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/clean-coords": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-4.7.3.tgz",
+      "integrity": "sha1-vD5lI6/kLciNul2hpxMHKlzW2g8=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/clone": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-4.7.3.tgz",
+      "integrity": "sha1-blB75NZI+mLF5s6Sb36Doi9Trmk="
+    },
+    "@turf/clusters": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-4.7.3.tgz",
+      "integrity": "sha1-6cIQAch5VKcUY0WYTx4R4IX07c4=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/clusters-dbscan": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-4.7.3.tgz",
+      "integrity": "sha1-sXl8XgXg8pXYSNWcPJRItOZYpFg=",
+      "requires": {
+        "@turf/clone": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "density-clustering": "1.3.0"
+      }
+    },
+    "@turf/clusters-kmeans": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-4.7.3.tgz",
+      "integrity": "sha1-YJoV1TeJnwJKn/rpYe+FApy1kCE=",
+      "requires": {
+        "@turf/clone": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "skmeans": "0.9.7"
+      }
+    },
+    "@turf/collect": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-4.7.3.tgz",
+      "integrity": "sha1-yStZIfiCKYPLzqyj4b1b7nOq6f8=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/inside": "^4.7.3",
+        "rbush": "^2.0.1"
+      }
+    },
+    "@turf/combine": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-4.7.3.tgz",
+      "integrity": "sha1-la0xJT4TyG/GE8tP92g621DDLgY=",
+      "requires": {
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/concave": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-4.7.3.tgz",
+      "integrity": "sha1-D4ChKhQrxAfvhjLEGCCFIANATZ4=",
+      "requires": {
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/tin": "^4.7.3",
+        "geojson-dissolve": "3.1.0"
+      }
+    },
+    "@turf/convex": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-4.7.3.tgz",
+      "integrity": "sha1-HgYJPYRT+lnBfWdVy17Jb0aHNjo=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "convex-hull": "^1.0.3"
+      }
+    },
+    "@turf/destination": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-4.7.3.tgz",
+      "integrity": "sha1-8eo7s3Bc9S/tE1p5F9STNuR7jS4=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/difference": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-4.7.4.tgz",
+      "integrity": "sha1-koYZDX3RUd2le645/pLkuIvDNho=",
+      "requires": {
+        "@turf/area": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "jsts": "1.3.0"
+      }
+    },
+    "@turf/dissolve": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-4.7.3.tgz",
+      "integrity": "sha1-NrcOaM9B1Lw7S4a5UtQCCI8aQXA=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/boolean-overlap": "^4.7.3",
+        "@turf/union": "^4.7.3",
+        "geojson-utils": "^1.1.0",
+        "get-closest": "^0.0.4",
+        "rbush": "^2.0.1"
+      }
+    },
+    "@turf/distance": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-4.7.3.tgz",
+      "integrity": "sha1-tatIoJpkJwbWXDm5GUM9XSzFcbE=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/envelope": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-4.7.3.tgz",
+      "integrity": "sha1-ImQqaTXlFYZr4HXIjwNIOiDAIJY=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/bbox-polygon": "^4.7.3"
+      }
+    },
+    "@turf/explode": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-4.7.3.tgz",
+      "integrity": "sha1-9+LvslrqA0EMzh6YFlhLqU/JGEY=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/flatten": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-4.7.3.tgz",
+      "integrity": "sha1-fqQJ+8b7TuLxQoNLQYbQ9p2oNQo=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/flip": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-4.7.3.tgz",
+      "integrity": "sha1-nXyVb6z2USER8QTUPhZ8tk983BY=",
+      "requires": {
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/great-circle": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-4.7.3.tgz",
+      "integrity": "sha1-gTJVdAq88M8tub/vJ0mxFgTAbNE=",
+      "requires": {
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/helpers": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-4.7.3.tgz",
+      "integrity": "sha1-vDEqxDyrPFMqSDFRxMOCxWSUKek="
+    },
+    "@turf/hex-grid": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-4.7.3.tgz",
+      "integrity": "sha1-bqzE0VPPQwd33q56SGmM+yeufsY=",
+      "requires": {
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/idw": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/idw/-/idw-4.7.3.tgz",
+      "integrity": "sha1-uKmyITJl4AYJ/7v4agWvF1I6OyU=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/centroid": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/square-grid": "^4.7.3"
+      }
+    },
+    "@turf/inside": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/inside/-/inside-4.7.3.tgz",
+      "integrity": "sha1-5KhJafKIaJGzQ7Ebg/2jCV+6VCw=",
+      "requires": {
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/interpolate": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-4.7.3.tgz",
+      "integrity": "sha1-B5YilcH1qP6RTkoC0CnSkF0cdFA=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/centroid": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/hex-grid": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/point-grid": "^4.7.3",
+        "@turf/square-grid": "^4.7.3",
+        "@turf/triangle-grid": "^4.7.3"
+      }
+    },
+    "@turf/intersect": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-4.7.4.tgz",
+      "integrity": "sha1-2V1dafvxMvg063ciUaHaKq4/M6M=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/truncate": "^4.7.3",
+        "jsts": "1.3.0"
+      }
+    },
+    "@turf/invariant": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-4.7.3.tgz",
+      "integrity": "sha1-U482fSPBE/yEnXDJpSS4Vjh0YB0="
+    },
+    "@turf/isobands": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-4.7.3.tgz",
+      "integrity": "sha1-SC7+3jzLQoxVKVJwkPz4t0eRrxQ=",
+      "requires": {
+        "@turf/area": "^3.7.0",
+        "@turf/bbox": "^3.14.0",
+        "@turf/explode": "^3.7.0",
+        "@turf/helpers": "^3.6.3",
+        "@turf/inside": "^3.7.0",
+        "@turf/invariant": "^3.13.0",
+        "grid-to-matrix": "^1.2.0",
+        "marchingsquares": "^1.2.0"
+      },
+      "dependencies": {
+        "@turf/area": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@turf/area/-/area-3.14.0.tgz",
+          "integrity": "sha1-8xl+1OlxDQLNi71VGyXEdv5H6Js=",
+          "requires": {
+            "@mapbox/geojson-area": "^0.2.2",
+            "@turf/meta": "^3.14.0"
+          }
+        },
+        "@turf/bbox": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-3.14.0.tgz",
+          "integrity": "sha1-zuXzlt3nisqc7eBeESLbGLxQRjU=",
+          "requires": {
+            "@turf/meta": "^3.14.0"
+          }
+        },
+        "@turf/explode": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-3.14.0.tgz",
+          "integrity": "sha1-8sweRqOXANVgJGbM1Q9ZpSNBuSw=",
+          "requires": {
+            "@turf/helpers": "^3.13.0",
+            "@turf/meta": "^3.14.0"
+          }
+        },
+        "@turf/helpers": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-3.13.0.tgz",
+          "integrity": "sha1-0GB4oUZM9WzbfqYk6h4TpxuIuAY="
+        },
+        "@turf/inside": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@turf/inside/-/inside-3.14.0.tgz",
+          "integrity": "sha1-1ravVYgsvbj5pVjcqYaJxnvTxZA=",
+          "requires": {
+            "@turf/invariant": "^3.13.0"
+          }
+        },
+        "@turf/invariant": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-3.13.0.tgz",
+          "integrity": "sha1-iSQzCM1WMgboHlxhYuDSL2GCL5A="
+        },
+        "@turf/meta": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-3.14.0.tgz",
+          "integrity": "sha1-jTBQwaD0S/QGpjO2vSjFEPe87ic="
+        }
+      }
+    },
+    "@turf/isolines": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-4.7.3.tgz",
+      "integrity": "sha1-MGxbXH3yRjJ3ZXRyUXfvc+M0K7U=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "grid-to-matrix": "1.2.0",
+        "marchingsquares": "1.2.0"
+      },
+      "dependencies": {
+        "grid-to-matrix": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/grid-to-matrix/-/grid-to-matrix-1.2.0.tgz",
+          "integrity": "sha1-sBbfTXb5lua3RmPquc65E1RmV+k=",
+          "requires": {
+            "@turf/helpers": "^4.1.0",
+            "@turf/invariant": "^4.1.0",
+            "@turf/meta": "^4.1.0"
+          }
+        },
+        "marchingsquares": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/marchingsquares/-/marchingsquares-1.2.0.tgz",
+          "integrity": "sha1-Nq4tzBcL5XbUJXmqw8RtqJq2UOY="
+        }
+      }
+    },
+    "@turf/kinks": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-4.7.3.tgz",
+      "integrity": "sha1-ZOGFH43RbtIS6ysnv9Q4Av5ANWU=",
+      "requires": {
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/line-arc": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-4.7.3.tgz",
+      "integrity": "sha1-MtbCMxv2O8rPY8F/xhm6pyn9zj8=",
+      "requires": {
+        "@turf/circle": "^4.7.3",
+        "@turf/destination": "^4.7.3",
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/line-chunk": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-4.7.3.tgz",
+      "integrity": "sha1-HZFPNQMh2gd1bAEl+1ES6ygqeK8=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/line-distance": "^4.7.3",
+        "@turf/line-slice-along": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/line-distance": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-distance/-/line-distance-4.7.3.tgz",
+      "integrity": "sha1-AKMwAOCI7l46jZK3uWuzMq83MAY=",
+      "requires": {
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/line-intersect": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-4.7.3.tgz",
+      "integrity": "sha1-Bys3OGN/egRUqscI+ZWjopdksFY=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/line-segment": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "geojson-rbush": "^1.0.1"
+      }
+    },
+    "@turf/line-offset": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-4.7.3.tgz",
+      "integrity": "sha1-o+JNHB2ZDL+jK52fPNFkRqfsCNU=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/line-overlap": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-4.7.3.tgz",
+      "integrity": "sha1-W+V602b2KZN+II8xG2Hv7jmVJIs=",
+      "requires": {
+        "@turf/boolean-point-on-line": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/line-segment": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/point-on-line": "^4.7.3",
+        "deep-equal": "^1.0.1",
+        "geojson-rbush": "^1.0.1"
+      }
+    },
+    "@turf/line-segment": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-4.7.3.tgz",
+      "integrity": "sha1-dx9x+mU9jmu8Wo2JIoMWPpSzTXo=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/line-slice": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-4.7.3.tgz",
+      "integrity": "sha1-+lRtjHF/dy6n1q/JlkllqkXhju8=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/point-on-line": "^4.7.3"
+      }
+    },
+    "@turf/line-slice-along": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-4.7.3.tgz",
+      "integrity": "sha1-3wUdEMu7KYUe5LfX4ZASS34NYss=",
+      "requires": {
+        "@turf/bearing": "^4.7.3",
+        "@turf/destination": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/line-split": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-4.7.3.tgz",
+      "integrity": "sha1-ItgRYto3hht9IoWQc63vIvivU9s=",
+      "requires": {
+        "@turf/flatten": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/line-intersect": "^4.7.3",
+        "@turf/line-segment": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/point-on-line": "^4.7.3",
+        "@turf/truncate": "^4.7.3",
+        "geojson-rbush": "^1.0.1"
+      }
+    },
+    "@turf/linestring-to-polygon": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/linestring-to-polygon/-/linestring-to-polygon-4.7.3.tgz",
+      "integrity": "sha1-9F/vjFRNiyiPW6WMK640mhj7WX8=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/mask": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-4.7.3.tgz",
+      "integrity": "sha1-U9C0yBFNC+n41JbdwEjuF61jneM=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/union": "^4.7.3",
+        "rbush": "^2.0.1"
+      }
+    },
+    "@turf/meta": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-4.7.4.tgz",
+      "integrity": "sha1-beLx6YkLj2S2aeS0fAmyCJMGOXc="
+    },
+    "@turf/midpoint": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-4.7.3.tgz",
+      "integrity": "sha1-mxLNXHxdFfzj1rALITiYLUl8FCY=",
+      "requires": {
+        "@turf/bearing": "^4.7.3",
+        "@turf/destination": "^4.7.3",
+        "@turf/distance": "^4.7.3"
+      }
+    },
+    "@turf/nearest": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/nearest/-/nearest-4.7.3.tgz",
+      "integrity": "sha1-/OFK4BmF/sazQ4ofnApHTPbgKuI=",
+      "requires": {
+        "@turf/distance": "^4.7.3"
+      }
+    },
+    "@turf/planepoint": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-4.7.3.tgz",
+      "integrity": "sha1-0FXcwh6vHG7Zm/mYcVf3O6Ch2n8=",
+      "requires": {
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/point-grid": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-4.7.3.tgz",
+      "integrity": "sha1-M7w8khtSGJfigsC4guEGUIBS7X0=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/inside": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/point-on-line": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-line/-/point-on-line-4.7.3.tgz",
+      "integrity": "sha1-lEoeeyxDdfSI6DzlXqs1RU6at7c=",
+      "requires": {
+        "@turf/bearing": "^4.7.3",
+        "@turf/destination": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/line-intersect": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/point-on-surface": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-surface/-/point-on-surface-4.7.3.tgz",
+      "integrity": "sha1-Jew2C+x/n6YS1wWAjPAxDXLCvl8=",
+      "requires": {
+        "@turf/center": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/explode": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/inside": "^4.7.3"
+      }
+    },
+    "@turf/point-to-line-distance": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-4.7.3.tgz",
+      "integrity": "sha1-HNF6J6lDi18643F69/CQgljfCGU=",
+      "requires": {
+        "@turf/bearing": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/rhumb-bearing": "^4.7.3",
+        "@turf/rhumb-distance": "^4.7.3"
+      }
+    },
+    "@turf/polygon-tangents": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-4.7.3.tgz",
+      "integrity": "sha1-nd+sm5s4QPTEO+ZdaTIfHNR6eyQ=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/polygon-to-linestring": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-linestring/-/polygon-to-linestring-4.7.3.tgz",
+      "integrity": "sha1-q4Z8DTlYG8QRxJ4CY/0YtGdBcaE=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
+      }
+    },
+    "@turf/polygonize": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-4.7.3.tgz",
+      "integrity": "sha1-D4jdrNccbywLlsac5nVVQ36hld8=",
+      "requires": {
+        "polygonize": "1.0.1"
+      }
+    },
+    "@turf/projection": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-4.7.3.tgz",
+      "integrity": "sha1-w+RXRdiTce5yDkOt1W8IhQ6QaUo=",
+      "requires": {
+        "@turf/clone": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/random": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-4.7.3.tgz",
+      "integrity": "sha1-Coo7hKHxW4kW1NzkNWa+suK9pSI=",
+      "requires": {
+        "geojson-random": "^0.2.2"
+      }
+    },
+    "@turf/rewind": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-4.7.3.tgz",
+      "integrity": "sha1-aYmfw+xT1hG1UFH6AMUVCNkDxb8=",
+      "requires": {
+        "@turf/boolean-clockwise": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/rhumb-bearing": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-4.7.3.tgz",
+      "integrity": "sha1-2xghticG+0A62/lBPMXla3kAYUY=",
+      "requires": {
+        "@turf/invariant": "^4.7.3",
+        "geodesy": "1.1.2"
+      }
+    },
+    "@turf/rhumb-destination": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-4.7.3.tgz",
+      "integrity": "sha1-G3QYjCgqeQ0wLn2ER6B3peEkKu4=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "geodesy": "1.1.2"
+      }
+    },
+    "@turf/rhumb-distance": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-4.7.3.tgz",
+      "integrity": "sha1-MO68a3hVAr2OCFSAaXEslwntItQ=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "geodesy": "1.1.2"
+      }
+    },
+    "@turf/sample": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-4.7.3.tgz",
+      "integrity": "sha1-0DBiDF44IHa33L5V74PEql7vJKs=",
+      "requires": {
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/sector": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-4.7.3.tgz",
+      "integrity": "sha1-b+6frYBn/ZTNdMhE/mNES2zcXxw=",
+      "requires": {
+        "@turf/circle": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/line-arc": "^4.7.3",
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/simplify": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-4.7.3.tgz",
+      "integrity": "sha1-Lv1bRo3N9HUdBe5jt6PqRkUIdfM=",
+      "requires": {
+        "@turf/clean-coords": "^4.7.3",
+        "@turf/clone": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "simplify-js": "^1.2.1"
+      }
+    },
+    "@turf/square": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-4.7.3.tgz",
+      "integrity": "sha1-kDkffBUg7WKSVIj0ZjFEJqXk0zw=",
+      "requires": {
+        "@turf/distance": "^4.7.3"
+      }
+    },
+    "@turf/square-grid": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-4.7.3.tgz",
+      "integrity": "sha1-s+iWsTKjT8x37TkH79mkRE22Ilk=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/tag": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-4.7.3.tgz",
+      "integrity": "sha1-WiT+3lgSYfHHxPkqZoFboTWUJ3A=",
+      "requires": {
+        "@turf/inside": "^4.7.3"
+      }
+    },
+    "@turf/tesselate": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-4.7.3.tgz",
+      "integrity": "sha1-Vgr3DCLwsd4fbDtw4r/fP4RLrO0=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "earcut": "^2.0.0"
+      }
+    },
+    "@turf/tin": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-4.7.3.tgz",
+      "integrity": "sha1-ZBYgkhHlZVOVYNz3MoWLcBFXrH8=",
+      "requires": {
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/transform-rotate": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-4.7.3.tgz",
+      "integrity": "sha1-4HqDfCcocmW/SRBQhnfFC4AWvGc=",
+      "requires": {
+        "@turf/centroid": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/rhumb-bearing": "^4.7.3",
+        "@turf/rhumb-destination": "^4.7.3",
+        "@turf/rhumb-distance": "^4.7.3"
+      }
+    },
+    "@turf/transform-scale": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-4.7.3.tgz",
+      "integrity": "sha1-8U1LqZLljJ8zwNcalrg0mBxFXrw=",
+      "requires": {
+        "@turf/bbox": "^4.7.3",
+        "@turf/center": "^4.7.3",
+        "@turf/centroid": "^4.7.3",
+        "@turf/clone": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/rhumb-bearing": "^4.7.3",
+        "@turf/rhumb-destination": "^4.7.3",
+        "@turf/rhumb-distance": "^4.7.3"
+      }
+    },
+    "@turf/transform-translate": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-4.7.3.tgz",
+      "integrity": "sha1-p6K8eeEXswrx5Z3iB6eDWFZ4tOw=",
+      "requires": {
+        "@turf/invariant": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/rhumb-destination": "^4.7.3"
+      }
+    },
+    "@turf/triangle-grid": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-4.7.3.tgz",
+      "integrity": "sha1-ztYTEcUcDRSD7AOP7cm70AF+iQA=",
+      "requires": {
+        "@turf/distance": "^4.7.3",
+        "@turf/helpers": "^4.7.3"
+      }
+    },
+    "@turf/truncate": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-4.7.3.tgz",
+      "integrity": "sha1-gnqN+P8Mn/+dzxpLMUXL3vgPuZM=",
+      "requires": {
+        "@turf/meta": "^4.7.3"
+      }
+    },
+    "@turf/turf": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-4.7.3.tgz",
+      "integrity": "sha1-HrY2l7RimuEwmqgLl9WV1+lfIcg=",
+      "requires": {
+        "@turf/along": "^4.7.3",
+        "@turf/area": "^4.7.3",
+        "@turf/bbox": "^4.7.3",
+        "@turf/bbox-clip": "^4.7.3",
+        "@turf/bbox-polygon": "^4.7.3",
+        "@turf/bearing": "^4.7.3",
+        "@turf/bezier": "^4.7.3",
+        "@turf/boolean-clockwise": "^4.7.3",
+        "@turf/boolean-contains": "^4.7.3",
+        "@turf/boolean-crosses": "^4.7.3",
+        "@turf/boolean-disjoint": "^4.7.3",
+        "@turf/boolean-equal": "^4.7.3",
+        "@turf/boolean-overlap": "^4.7.3",
+        "@turf/boolean-point-on-line": "^4.7.3",
+        "@turf/boolean-within": "^4.7.3",
+        "@turf/buffer": "^4.7.3",
+        "@turf/center": "^4.7.3",
+        "@turf/center-of-mass": "^4.7.3",
+        "@turf/centroid": "^4.7.3",
+        "@turf/circle": "^4.7.3",
+        "@turf/clean-coords": "^4.7.3",
+        "@turf/clone": "^4.7.3",
+        "@turf/clusters": "^4.7.3",
+        "@turf/clusters-dbscan": "^4.7.3",
+        "@turf/clusters-kmeans": "^4.7.3",
+        "@turf/collect": "^4.7.3",
+        "@turf/combine": "^4.7.3",
+        "@turf/concave": "^4.7.3",
+        "@turf/convex": "^4.7.3",
+        "@turf/destination": "^4.7.3",
+        "@turf/difference": "^4.7.3",
+        "@turf/dissolve": "^4.7.3",
+        "@turf/distance": "^4.7.3",
+        "@turf/envelope": "^4.7.3",
+        "@turf/explode": "^4.7.3",
+        "@turf/flatten": "^4.7.3",
+        "@turf/flip": "^4.7.3",
+        "@turf/great-circle": "^4.7.3",
+        "@turf/helpers": "^4.7.3",
+        "@turf/hex-grid": "^4.7.3",
+        "@turf/idw": "^4.7.3",
+        "@turf/inside": "^4.7.3",
+        "@turf/interpolate": "^4.7.3",
+        "@turf/intersect": "^4.7.3",
+        "@turf/invariant": "^4.7.3",
+        "@turf/isobands": "^4.7.3",
+        "@turf/isolines": "^4.7.3",
+        "@turf/kinks": "^4.7.3",
+        "@turf/line-arc": "^4.7.3",
+        "@turf/line-chunk": "^4.7.3",
+        "@turf/line-distance": "^4.7.3",
+        "@turf/line-intersect": "^4.7.3",
+        "@turf/line-offset": "^4.7.3",
+        "@turf/line-overlap": "^4.7.3",
+        "@turf/line-segment": "^4.7.3",
+        "@turf/line-slice": "^4.7.3",
+        "@turf/line-slice-along": "^4.7.3",
+        "@turf/line-split": "^4.7.3",
+        "@turf/linestring-to-polygon": "^4.7.3",
+        "@turf/mask": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "@turf/midpoint": "^4.7.3",
+        "@turf/nearest": "^4.7.3",
+        "@turf/planepoint": "^4.7.3",
+        "@turf/point-grid": "^4.7.3",
+        "@turf/point-on-line": "^4.7.3",
+        "@turf/point-on-surface": "^4.7.3",
+        "@turf/point-to-line-distance": "^4.7.3",
+        "@turf/polygon-tangents": "^4.7.3",
+        "@turf/polygon-to-linestring": "^4.7.3",
+        "@turf/polygonize": "^4.7.3",
+        "@turf/random": "^4.7.3",
+        "@turf/rewind": "^4.7.3",
+        "@turf/rhumb-bearing": "^4.7.3",
+        "@turf/rhumb-destination": "^4.7.3",
+        "@turf/rhumb-distance": "^4.7.3",
+        "@turf/sample": "^4.7.3",
+        "@turf/sector": "^4.7.3",
+        "@turf/simplify": "^4.7.3",
+        "@turf/square": "^4.7.3",
+        "@turf/square-grid": "^4.7.3",
+        "@turf/tag": "^4.7.3",
+        "@turf/tesselate": "^4.7.3",
+        "@turf/tin": "^4.7.3",
+        "@turf/transform-rotate": "^4.7.3",
+        "@turf/transform-scale": "^4.7.3",
+        "@turf/transform-translate": "^4.7.3",
+        "@turf/triangle-grid": "^4.7.3",
+        "@turf/truncate": "^4.7.3",
+        "@turf/union": "^4.7.3",
+        "@turf/unkink-polygon": "^4.7.3",
+        "@turf/within": "^4.7.3"
+      }
+    },
+    "@turf/union": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-4.7.3.tgz",
+      "integrity": "sha1-AS1Kx0ZdbK1n/klI1AG3+L4P5BI=",
+      "requires": {
+        "jsts": "1.3.0"
+      }
+    },
+    "@turf/unkink-polygon": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-4.7.3.tgz",
+      "integrity": "sha1-yka+3x+fO0f3WPQ6ZPCJQUyXS5M=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/meta": "^4.7.3",
+        "simplepolygon": "1.2.1"
+      }
+    },
+    "@turf/within": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@turf/within/-/within-4.7.3.tgz",
+      "integrity": "sha1-Qas8FS9qjAXKpaNFyX3TNNSa7xM=",
+      "requires": {
+        "@turf/helpers": "^4.7.3",
+        "@turf/inside": "^4.7.3"
+      }
+    },
+    "affine-hull": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
+      "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
+      "requires": {
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "convex-hull": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
+      "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
+      "requires": {
+        "affine-hull": "^1.0.0",
+        "incremental-convex-hull": "^1.0.1",
+        "monotone-convex-hull-2d": "^1.0.1"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "csv-write-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/csv-write-stream/-/csv-write-stream-2.0.0.tgz",
+      "integrity": "sha1-/C2iGkjW6l+MF/3jnPuRHk8CkrA=",
+      "requires": {
+        "argparse": "^1.0.7",
+        "generate-object-property": "^1.0.0",
+        "ndjson": "^1.3.0"
+      }
+    },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-geo": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.3.tgz",
+      "integrity": "sha512-n30yN9qSKREvV2fxcrhmHUdXP9TNH7ZZj3C/qnaoU0cVf/Ea85+yT7HY7i8ySPwkwjCNYtmKqQFTvLFngfkItQ==",
+      "requires": {
+        "d3-array": "1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "density-clustering": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
+      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
+    },
+    "earcut": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.4.tgz",
+      "integrity": "sha512-ttRjmPD5oaTtXOoxhFp9aZvMB14kBjapYaiBuzBB1elOgSLU9P2Ev86G2OClBg+uspUXERsIzXKpUWweH2K4Xg=="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "geodesy": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/geodesy/-/geodesy-1.1.2.tgz",
+      "integrity": "sha512-E9SJT90FU+jloMUllVlBxO/nhExNKdlu7BCrzfxtbzg2E6gU0Go3RFTUd3Ag1mEUVRrCsAnhLZQ756H3Uc6RLw=="
+    },
+    "geojson-dissolve": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-dissolve/-/geojson-dissolve-3.1.0.tgz",
+      "integrity": "sha1-hoIycWgKGjgfPnLwJki7zHEOzaE=",
+      "requires": {
+        "@turf/meta": "^3.7.5",
+        "geojson-flatten": "^0.2.1",
+        "geojson-linestring-dissolve": "0.0.1",
+        "topojson-client": "^3.0.0",
+        "topojson-server": "^3.0.0"
+      },
+      "dependencies": {
+        "@turf/meta": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-3.14.0.tgz",
+          "integrity": "sha1-jTBQwaD0S/QGpjO2vSjFEPe87ic="
+        }
+      }
+    },
+    "geojson-equality": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
+      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
+      "requires": {
+        "deep-equal": "^1.0.0"
+      }
+    },
+    "geojson-flatten": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-0.2.2.tgz",
+      "integrity": "sha512-P9lzhr2NTsEjcVRmTBf/taXXSEw8Vwp6ITtY8oS54cvGuq1z0/d1BILv3E6IPRv83+XLLXGprOTvXxEq1yxJ/w==",
+      "requires": {
+        "concat-stream": "~1.6.0",
+        "minimist": "1.2.0"
+      }
+    },
+    "geojson-linestring-dissolve": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/geojson-linestring-dissolve/-/geojson-linestring-dissolve-0.0.1.tgz",
+      "integrity": "sha1-CKuM3zhukZ01oOs4+hxVDgIIONs="
+    },
+    "geojson-polygon-self-intersections": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.0.tgz",
+      "integrity": "sha1-RRxJ6J4BA1iMYlI2PFmNc3FrF0Y=",
+      "requires": {
+        "rbush": "^2.0.1"
+      }
+    },
+    "geojson-random": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/geojson-random/-/geojson-random-0.2.2.tgz",
+      "integrity": "sha1-q0g48SatxeFvj5TmVd74IPkRnbw="
+    },
+    "geojson-rbush": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-1.2.0.tgz",
+      "integrity": "sha1-7KO2o6+4maRT74LV4jcwkuINd+U=",
+      "requires": {
+        "@turf/meta": "^4.6.0",
+        "rbush": "^2.0.1"
+      }
+    },
+    "geojson-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-utils/-/geojson-utils-1.1.0.tgz",
+      "integrity": "sha1-6P+0yBwKdbPjBvUYcmXW8jBA9Qs="
+    },
+    "get-closest": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
+      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
+    },
+    "grid-to-matrix": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/grid-to-matrix/-/grid-to-matrix-1.4.0.tgz",
+      "integrity": "sha512-EJwb1ZM7Sgt1II/C1pP4PSVyhCs2zsSNNlvJ5Dadc9n8zMBb/OmQY68zNIByWhGe97dE5/CL3/hKLrgj/lYIiA==",
+      "requires": {
+        "@turf/helpers": "5.x",
+        "@turf/invariant": "5.x",
+        "@turf/meta": "5.x"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        },
+        "@turf/invariant": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        },
+        "@turf/meta": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
+          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
+        }
+      }
+    },
+    "incremental-convex-hull": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
+      "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
+      "requires": {
+        "robust-orientation": "^1.1.2",
+        "simplicial-complex": "^1.0.0"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsts": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-1.3.0.tgz",
+      "integrity": "sha1-6Tp2+XrJvafUYl2dZHDw1grIDkU="
+    },
+    "lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
+    },
+    "marchingsquares": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/marchingsquares/-/marchingsquares-1.3.2.tgz",
+      "integrity": "sha512-I7rhEHtG6S9qWHNKr6qjOCur3YMmJ9Q0cr9OmMDcvyH3K4h0Sk9zxsE+U5PlH5aBnNoXkbm59w5Ju4U2x6+1eQ=="
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "monotone-convex-hull-2d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
+      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+      "requires": {
+        "robust-orientation": "^1.1.3"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      }
+    },
+    "polygonize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/polygonize/-/polygonize-1.0.1.tgz",
+      "integrity": "sha1-UftwQJFL4PvEOwvVTUIddfwq56Y=",
+      "requires": {
+        "@turf/envelope": "^4.3.0",
+        "@turf/helpers": "^4.3.0",
+        "@turf/inside": "^4.3.0",
+        "@turf/invariant": "^4.3.0",
+        "@turf/meta": "^4.3.0"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "progress-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
+      "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
+      "requires": {
+        "speedometer": "~1.0.0",
+        "through2": "~2.0.3"
+      }
+    },
+    "quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+    },
+    "rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "requires": {
+        "quickselect": "^1.0.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "robust-orientation": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
+      "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "requires": {
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
+      }
+    },
+    "robust-scale": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "requires": {
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
+      }
+    },
+    "robust-subtract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+    },
+    "robust-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "simplepolygon": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/simplepolygon/-/simplepolygon-1.2.1.tgz",
+      "integrity": "sha1-SCUKaoUydeluQscQX1B9oA3GfWQ=",
+      "requires": {
+        "@turf/area": "^3.13.0",
+        "@turf/helpers": "^3.13.0",
+        "@turf/inside": "^4.5.2",
+        "@turf/within": "^3.13.0",
+        "debug": "^2.6.3",
+        "geojson-polygon-self-intersections": "^1.1.2",
+        "rbush": "^2.0.1"
+      },
+      "dependencies": {
+        "@turf/area": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@turf/area/-/area-3.14.0.tgz",
+          "integrity": "sha1-8xl+1OlxDQLNi71VGyXEdv5H6Js=",
+          "requires": {
+            "@mapbox/geojson-area": "^0.2.2",
+            "@turf/meta": "^3.14.0"
+          }
+        },
+        "@turf/helpers": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-3.13.0.tgz",
+          "integrity": "sha1-0GB4oUZM9WzbfqYk6h4TpxuIuAY="
+        },
+        "@turf/invariant": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-3.13.0.tgz",
+          "integrity": "sha1-iSQzCM1WMgboHlxhYuDSL2GCL5A="
+        },
+        "@turf/meta": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-3.14.0.tgz",
+          "integrity": "sha1-jTBQwaD0S/QGpjO2vSjFEPe87ic="
+        },
+        "@turf/within": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@turf/within/-/within-3.14.0.tgz",
+          "integrity": "sha1-iRpXgyPCkrl5ImkDLddIcODhTFM=",
+          "requires": {
+            "@turf/helpers": "^3.13.0",
+            "@turf/inside": "^3.14.0"
+          },
+          "dependencies": {
+            "@turf/inside": {
+              "version": "3.14.0",
+              "resolved": "https://registry.npmjs.org/@turf/inside/-/inside-3.14.0.tgz",
+              "integrity": "sha1-1ravVYgsvbj5pVjcqYaJxnvTxZA=",
+              "requires": {
+                "@turf/invariant": "^3.13.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "simplicial-complex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
+      "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
+      "requires": {
+        "bit-twiddle": "^1.0.0",
+        "union-find": "^1.0.0"
+      }
+    },
+    "simplify-js": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/simplify-js/-/simplify-js-1.2.3.tgz",
+      "integrity": "sha512-0IkEqs+5c5vROkHaifGfbqHf5tYDcsTBy6oJPRbFCSwp2uzEr+PpH3dNP7wD8O3d7zdUCjLVq1/xHkwA/JjlFA=="
+    },
+    "skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
+    },
+    "speedometer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
+      "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI="
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "^2.0.2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stringify-stream/-/stringify-stream-1.0.5.tgz",
+      "integrity": "sha1-5RQHqP3Eyg4cYvFJhous9c8gQFA=",
+      "requires": {
+        "readable-stream": "~2.1.0"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+          "requires": {
+            "buffer-shims": "^1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "topojson-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
+      "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
+      "requires": {
+        "commander": "2"
+      }
+    },
+    "topojson-server": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.0.tgz",
+      "integrity": "sha1-N4546Hw5cqe1vixdYENptrrmnF4=",
+      "requires": {
+        "commander": "2"
+      }
+    },
+    "two-product": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+    },
+    "two-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "union-find": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
+      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "wgs84": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+      "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
+    },
+    "which-polygon": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/which-polygon/-/which-polygon-2.2.0.tgz",
+      "integrity": "sha512-P2+zRXPqUsTVm4moH8gm7ZTlLtOemy4+EY8elJohjJNMTNpkXLFrlI7i2zUYJD8zHopgKH5TuBmYXca3ZLtMkg==",
+      "requires": {
+        "lineclip": "^1.1.5",
+        "rbush": "^2.0.1"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    }
+  }
+}


### PR DESCRIPTION
As discussed in https://github.com/mapbox/frontend-platform-team/issues/44, we are planning to move this repository the `labs` subdomain.
 
This PR adds:
- A canonical link to help search engines discern between duplicates and the original  `mapbox.com/malaria-mapping`.
- Added `.artifacts.yml` and `_config.yml` to allow for publishing via Publisher.